### PR TITLE
Module support

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,3 +10,5 @@ addons.zip
 *.so
 *.dylib
 *.dll
+*.o
+__pycache__

--- a/README.md
+++ b/README.md
@@ -44,7 +44,7 @@ Installation as a Godot module requires recompilation of the Godot engine. This 
 1. Clone or download the [Godot engine](https://github.com/godotengine/godot) following [this guide](https://docs.godotengine.org/en/3.5/development/compiling/getting_source.html).
 1. Download the project source via the [releases page](https://github.com/ashtonmeuser/godot-wasm/releases) or Code → Download ZIP on GitHub.
 1. Include the entire Godot Wasm directory within the *godot/modules* directory.
-1. Rename the Godot Wasm directory to *wasm*. All project files e.g. *config.py* should now be in *godot/modules/wasm*.
+1. Rename the Godot Wasm directory to *wasm*. All project files e.g. *SCsub* should now be in *godot/modules/wasm*.
 
 Recompile the Godot engine following [this guide](https://docs.godotengine.org/en/3.5/development/compiling/index.html#toc-devel-compiling). More information on custom Godot modules can be found in [this guide](https://docs.godotengine.org/en/3.5/development/cpp/custom_modules_in_cpp.html).
 

--- a/README.md
+++ b/README.md
@@ -22,9 +22,13 @@
 
 A Godot addon allowing for loading and interacting with [WebAssembly (Wasm)](https://webassembly.org) modules from GDScript. Note that this project is still in development.
 
-This [GDNative](https://docs.godotengine.org/en/stable/tutorials/scripting/gdnative/what_is_gdnative.html) addon uses [Wasmer](https://wasmer.io) as the WebAssembly runtime.
+Godot Wasm can be used either as a [GDNative](https://docs.godotengine.org/en/stable/tutorials/scripting/gdnative/what_is_gdnative.html) addon or Godot module. It uses [Wasmer](https://wasmer.io) as the WebAssembly runtime.
 
 ## Installation
+
+Godot Wasm supports installation via addon or module. Installing as an addon is far faster and simpler and requires merely including the asset in your Godot project while installing the module requires recompilation of the Godot engine. Note that exporting to web/HTML5 is only supported for modules (see [#15](https://github.com/ashtonmeuser/godot-wasm/issues/15)).
+
+### Addon
 
 Installation in a Godot project involves simply downloading and installing a zip file from Godot's UI. Recompilation of the engine is *not* required.
 
@@ -32,6 +36,19 @@ Installation in a Godot project involves simply downloading and installing a zip
 1. In Godot's Asset Library tab, click Import and select the addon zip file. Follow prompts to complete installation of the addon.
 
 Alternatively, you can use the Asset Library tab within the Godot editor, search for "Wasm", and follow the prompts to install. Yet another alternative is downloading directly from the [asset page](https://godotengine.org/asset-library/asset/1798) and following the installation instructions above. Note that the Asset Library has an approval process that can take several days and may therefore be a version or two behind.
+
+### Godot Module
+
+Installation as a Godot module requires recompilation of the Godot engine. This enables exporting to web/HTML5.
+
+1. Clone or download the [Godot engine](https://github.com/godotengine/godot) following [this guide](https://docs.godotengine.org/en/3.5/development/compiling/getting_source.html).
+1. Download the project source via the [releases page](https://github.com/ashtonmeuser/godot-wasm/releases) or Code → Download ZIP on GitHub.
+1. Include the entire Godot Wasm directory within the *godot/modules* directory.
+1. Rename the Godot Wasm directory to *wasm*. All project files e.g. *config.py* should now be in *godot/modules/wasm*.
+
+Recompile the Godot engine following [this guide](https://docs.godotengine.org/en/3.5/development/compiling/index.html#toc-devel-compiling). More information on custom Godot modules can be found in [this guide](https://docs.godotengine.org/en/3.5/development/cpp/custom_modules_in_cpp.html).
+
+To export using the customized engine, you'll also need to recompile the export templates (documented in the Engine compilation guide).
 
 ## Usage
 
@@ -56,7 +73,7 @@ Once installed as an addon in a Godot project, the Godot Wasm addon class can be
 ### Exporting Godot Project
 
 > **Note**
-> Exporting to web/HTML5 using a GDNative addon is not supported by Godot. See [godotengine/godot#12243](https://github.com/godotengine/godot/issues/12243).
+> Exporting to web/HTML5 using a GDNative addon is not supported by Godot. See [godotengine/godot#12243](https://github.com/godotengine/godot/issues/12243). Install as a Godot Module to enable web/HTML5 exports.
 
 Exporting from Godot may require the following additional steps. See the export configuration of the [example Godot project](https://github.com/ashtonmeuser/godot-wasm/tree/master/examples) for a practical illustration.
 

--- a/SConstruct
+++ b/SConstruct
@@ -56,7 +56,7 @@ if env['download_wasmer'] or not os.path.isdir('wasmer'):
 
 # Check platform specifics
 if env['platform'] == 'osx':
-    env.Append(CCFLAGS=['-arch', 'x86_64'])
+    env.Append(CCFLAGS=['-arch', 'x86_64', '-Wall'])
     env.Append(CXXFLAGS=['-std=c++17'])
     env.Append(LINKFLAGS=['-arch', 'x86_64', '-framework', 'Security'])
     if env['target'] in ('debug', 'd'):

--- a/SConstruct
+++ b/SConstruct
@@ -5,6 +5,7 @@ import re
 from urllib import request
 import tarfile
 
+# Initial options inheriting from CLI args
 opts = Variables([], ARGUMENTS)
 
 # Define options

--- a/SCsub
+++ b/SCsub
@@ -25,4 +25,4 @@ module_env.Append(CPPPATH=['wasmer/include'])
 module_env.Append(CPPDEFINES=["GODOT_MODULE"])
 
 # Module sources
-module_env.add_source_files(env.modules_sources, ['register_types.cpp', env.Glob('src/*.cpp')])
+module_env.add_source_files(env.modules_sources, ['register_types.cpp', env.Glob('src/*.cpp', exclude='src/godot-library.cpp')])

--- a/SCsub
+++ b/SCsub
@@ -1,0 +1,28 @@
+# Import env and create module-specific clone
+Import('env')
+module_env = env.Clone()
+
+# Check platform specifics
+if env['platform']=='linuxbsd':
+    module_env['LIBSUFFIX'] = '.a'
+    module_env.Append(CXXFLAGS=['-std=c++17'])
+elif env['platform']=='osx':
+    module_env['LIBSUFFIX'] = '.a'
+    module_env.Append(CXXFLAGS=['-std=c++17'])
+    env.Append(LINKFLAGS=['-framework', 'Security'])
+elif env['platform']=='windows':
+    module_env['LIBSUFFIX'] = '.lib'
+
+# Explicit static libraries
+wasmer_library = env.File('{}wasmer{}'.format(env['LIBPREFIX'], module_env.get('LIBWASMERSUFFIX', module_env['LIBSUFFIX'])))
+
+# Linked libraries (global env) and includes (cloned env)
+env.Append(LIBPATH=[env.Dir('wasmer/lib').abspath])
+env.Append(LIBS=[wasmer_library])
+module_env.Append(CPPPATH=['wasmer/include'])
+
+# Defines for module agnosticism
+module_env.Append(CPPDEFINES=["GODOT_MODULE"])
+
+# Module sources
+module_env.add_source_files(env.modules_sources, ['register_types.cpp', env.Glob('src/*.cpp')])

--- a/config.py
+++ b/config.py
@@ -1,0 +1,5 @@
+def can_build(env, platform):
+    return True
+
+def configure(env):
+    pass

--- a/register_types.cpp
+++ b/register_types.cpp
@@ -1,0 +1,16 @@
+#ifdef GODOT_MODULE
+
+#include "register_types.h"
+
+#include "core/class_db.h"
+#include "src/godot-wasm.h"
+#include "src/stream-peer-wasm.h"
+
+void register_wasm_types() {
+    ClassDB::register_class<godot::Wasm>();
+    ClassDB::register_class<godot::StreamPeerWasm>();
+}
+
+void unregister_wasm_types() { }
+
+#endif

--- a/register_types.h
+++ b/register_types.h
@@ -1,0 +1,2 @@
+void register_wasm_types();
+void unregister_wasm_types();

--- a/src/defs.h
+++ b/src/defs.h
@@ -1,17 +1,37 @@
 #ifndef GODOT_WASM_DEFS_H
 #define GODOT_WASM_DEFS_H
 
+#ifdef GODOT_MODULE // Godot includes when building module
+  #include "core/io/stream_peer.h"
+#else // Godot addon includes
+  #include <Godot.hpp>
+  #include <StreamPeerGDNative.hpp>
+#endif
+
 namespace {
   #ifdef __GNUC__
     #define UNLIKELY(cond) __builtin_expect(!!(cond), 0)
   #else
     #define UNLIKELY(cond) cond
   #endif
-  #define GDERROR(error) GODOT_##error
-  #define PRINT_ERROR(message) godot::Godot::print_error("Godot Wasm: " + godot::String(message), __func__, __FILE__, __LINE__);
+  #ifdef GODOT_MODULE
+    #define NS
+    #define godot_error Error
+    #define PRINT_ERROR(message) print_error("Godot Wasm: " + String(message))
+    #define REGISTRATION_METHOD _bind_methods
+  #else
+    #define NS godot
+    #define OK GODOT_OK
+    #define ERR_INVALID_DATA GODOT_ERR_INVALID_DATA
+    #define ERR_COMPILATION_FAILED GODOT_ERR_COMPILATION_FAILED
+    #define ERR_CANT_CREATE GODOT_ERR_CANT_CREATE
+    #define PRINT_ERROR(message) godot::Godot::print_error("Godot Wasm: " + godot::String(message), __func__, __FILE__, __LINE__)
+    #define GDCLASS GODOT_CLASS
+    #define REGISTRATION_METHOD _register_methods
+  #endif
   #define FAIL(message, ret) do { PRINT_ERROR(message); return ret; } while (0)
   #define FAIL_IF(cond, message, ret) if (UNLIKELY(cond)) FAIL(message, ret)
-  #define NULL_VARIANT godot::Variant()
+  #define NULL_VARIANT NS::Variant()
   #define PAGE_SIZE 65536
 }
 

--- a/src/godot-library.cpp
+++ b/src/godot-library.cpp
@@ -1,3 +1,5 @@
+#ifndef GODOT_MODULE
+
 #include "godot-wasm.h"
 #include "stream-peer-wasm.h"
 
@@ -15,3 +17,5 @@ extern "C" void GDN_EXPORT wasm_nativescript_init(void *handle) {
   godot::register_class<godot::Wasm>();
   godot::register_class<godot::StreamPeerWasm>();
 }
+
+#endif

--- a/src/godot-wasm.cpp
+++ b/src/godot-wasm.cpp
@@ -124,6 +124,8 @@ namespace godot {
       ClassDB::bind_method(D_METHOD("inspect"), &Wasm::inspect);
       ClassDB::bind_method(D_METHOD("global", "name"), &Wasm::global);
       ClassDB::bind_method(D_METHOD("function", "name", "args"), &Wasm::function);
+      ClassDB::bind_method(D_METHOD("get_stream"), &Wasm::get_stream);
+      ADD_PROPERTY(PropertyInfo(Variant::OBJECT, "stream"), "", "get_stream");
     #else
       register_method("compile", &Wasm::compile);
       register_method("instantiate", &Wasm::instantiate);
@@ -152,6 +154,10 @@ namespace godot {
   }
 
   void Wasm::_init() { }
+
+  Ref<StreamPeerWasm> Wasm::get_stream() const {
+    return stream;
+  };
 
   godot_error Wasm::compile(PoolByteArray bytecode) {
     // Reset

--- a/src/godot-wasm.cpp
+++ b/src/godot-wasm.cpp
@@ -77,17 +77,18 @@ namespace {
         wasm_functype_t* func_type = wasm_externtype_as_functype((wasm_externtype_t*)type);
         const wasm_valtype_vec_t* func_params = wasm_functype_params(func_type);
         const wasm_valtype_vec_t* func_results = wasm_functype_results(func_type);
-        NS::Array param_types, result_types;
+        NS::Array signature, param_types, result_types;
         for (uint16_t i = 0; i < func_params->size; i++) param_types.append(get_value_type(wasm_valtype_kind(func_params->data[i])));
         for (uint16_t i = 0; i < func_results->size; i++) result_types.append(get_value_type(wasm_valtype_kind(func_results->data[i])));
-        return NS::Array().make(param_types, result_types);
-        return NS::Array();
+        signature.append(param_types);
+        signature.append(result_types);
+        return signature;
       } case WASM_EXTERN_GLOBAL: {
         wasm_globaltype_t* global_type = wasm_externtype_as_globaltype((wasm_externtype_t*)type);
-        const NS::Variant variant_type = get_value_type(wasm_valtype_kind(wasm_globaltype_content(global_type)));
-        const NS::Variant variant_mutability = NS::Variant(wasm_globaltype_mutability(global_type) == WASM_VAR ? true : false);
-        return NS::Array().make(variant_type, variant_mutability);
-        return NS::Array();
+        NS::Array signature;
+        signature.append(get_value_type(wasm_valtype_kind(wasm_globaltype_content(global_type))));
+        signature.append(NS::Variant(wasm_globaltype_mutability(global_type) == WASM_VAR ? true : false));
+        return signature;
       } default: throw std::invalid_argument("Extern type has no signature");
     }
   }

--- a/src/godot-wasm.cpp
+++ b/src/godot-wasm.cpp
@@ -8,6 +8,8 @@ namespace {
   struct context_callback: public context_extern {
     NS::Object* target;
     NS::String method; // External name; doesn't necessarily match import name
+    context_callback() { }
+    context_callback(uint16_t i): context_extern { i } { }
   };
 
   NS::Variant decode_variant(wasm_val_t value) {
@@ -36,7 +38,7 @@ namespace {
   void push_results(NS::Variant variant, wasm_val_vec_t* results) { // TODO: Rename
     if (results->size <= 0) return;
     if (variant.get_type() == NS::Variant::ARRAY) {
-      NS::Array array = (NS::Array)variant;
+      NS::Array array = variant.operator NS::Array();
       if (array.size() != results->size) throw std::length_error("Results length mismatch");
       for (uint16_t i = 0; i < results->size; i++) results->data[i] = encode_variant(array[i]);
     } else if (results->size == 1) {
@@ -316,7 +318,7 @@ namespace godot {
       const String key = decode_name(wasm_importtype_module(imports.data[i])) + "." + decode_name(wasm_importtype_name(imports.data[i]));
       switch (kind) {
         case WASM_EXTERN_FUNC:
-          import_funcs[key] = context_callback { { i } };
+          import_funcs[key] = { i };
           break;
         default: throw std::invalid_argument("Import type not implemented");
       }
@@ -331,10 +333,10 @@ namespace godot {
       const String key = decode_name(wasm_exporttype_name(exports.data[i]));
       switch (kind) {
         case WASM_EXTERN_FUNC:
-          export_funcs[key] = context_extern { i };
+          export_funcs[key] = { i };
           break;
         case WASM_EXTERN_GLOBAL:
-          export_globals[key] = context_extern { i };
+          export_globals[key] = { i };
           break;
         case WASM_EXTERN_MEMORY:
           memory_index = i;

--- a/src/godot-wasm.cpp
+++ b/src/godot-wasm.cpp
@@ -298,7 +298,7 @@ namespace godot {
       const String key = decode_name(wasm_importtype_module(imports.data[i])) + "." + decode_name(wasm_importtype_name(imports.data[i]));
       switch (kind) {
         case WASM_EXTERN_FUNC:
-          import_funcs[key] = context_callback { i };
+          import_funcs[key] = context_callback { { i } };
           break;
         default: throw std::invalid_argument("Import type not implemented");
       }
@@ -331,8 +331,6 @@ namespace godot {
     wasm_module_imports(module, &imports);
     const wasm_externtype_t* type = wasm_importtype_type(imports.data[context->index]);
     const wasm_functype_t* func_type = wasm_externtype_as_functype((wasm_externtype_t*)type);
-    wasm_valtype_vec_t* params = (wasm_valtype_vec_t*)wasm_functype_params(func_type);
-    wasm_valtype_vec_t* results = (wasm_valtype_vec_t*)wasm_functype_results(func_type);
     wasm_func_t* func = wasm_func_new_with_env(store, func_type, callback_wrapper, context, NULL);
     return func;
   }

--- a/src/godot-wasm.h
+++ b/src/godot-wasm.h
@@ -43,6 +43,7 @@ namespace godot {
       Variant global(String name);
       uint64_t mem_size();
       Ref<StreamPeerWasm> stream;
+      Ref<StreamPeerWasm> get_stream() const;
   };
 }
 

--- a/src/godot-wasm.h
+++ b/src/godot-wasm.h
@@ -5,7 +5,6 @@
 #include <vector>
 #include <stdexcept>
 #include <map>
-#include <Godot.hpp>
 #include "wasmer.h"
 #include "defs.h"
 #include "stream-peer-wasm.h"
@@ -17,7 +16,7 @@ namespace {
 
 namespace godot {
   class Wasm : public Reference {
-    GODOT_CLASS(Wasm, Reference)
+    GDCLASS(Wasm, Reference);
 
     private:
       wasm_engine_t* engine;
@@ -32,7 +31,7 @@ namespace godot {
       wasm_func_t* create_callback(context_callback* context);
 
     public:
-      static void _register_methods();
+      static void REGISTRATION_METHOD();
       Wasm();
       ~Wasm();
       void _init();

--- a/src/stream-peer-wasm.cpp
+++ b/src/stream-peer-wasm.cpp
@@ -1,33 +1,33 @@
 #include "stream-peer-wasm.h"
 
 namespace {
-  #define GDNATIVE_VERSION { 3, 5 } // No clue if this is correct
-
-  // StreamPeerGDNative interface
-  godot_error _get_data(void *user, uint8_t *p_buffer, int p_bytes) { return ((godot::StreamPeerWasm *)user)->get_data(p_buffer, p_bytes); }
-  godot_error _get_partial_data(void *user, uint8_t *p_buffer, int p_bytes, int *r_received) { return ((godot::StreamPeerWasm *)user)->get_partial_data(p_buffer, p_bytes, r_received); }
-  godot_error _put_data(void *user, const uint8_t *p_data, int p_bytes) { return ((godot::StreamPeerWasm *)user)->put_data(p_data, p_bytes); }
-  godot_error _put_partial_data(void *user, const uint8_t *p_data, int p_bytes, int *r_sent) { return ((godot::StreamPeerWasm *)user)->put_partial_data(p_data, p_bytes, r_sent); }
-  int _get_available_bytes(const void *user) { return ((godot::StreamPeerWasm *)user)->get_available_bytes(); }
+  #ifdef GODOT_MODULE
+    #define INTERFACE_DEFINE
+    #define INTERFACE_INIT
+  #else
+    #define INTERFACE_DEFINE interface = { { 3, 5 }, this, &_get_data, &_get_partial_data, &_put_data, &_put_partial_data, &_get_available_bytes, NULL }
+    #define INTERFACE_INIT net_api->godot_net_bind_stream_peer(_owner, &interface)
+    godot_error _get_data(void* user, uint8_t* p_buffer, int p_bytes) { return ((godot::StreamPeerWasm*)user)->get_data(p_buffer, p_bytes); }
+    godot_error _get_partial_data(void* user, uint8_t* p_buffer, int p_bytes, int* r_received) { return ((godot::StreamPeerWasm*)user)->get_partial_data(p_buffer, p_bytes, *r_received); }
+    godot_error _put_data(void* user, const uint8_t* p_data, int p_bytes) { return ((godot::StreamPeerWasm*)user)->put_data(p_data, p_bytes); }
+    godot_error _put_partial_data(void* user, const uint8_t* p_data, int p_bytes, int* r_sent) { return ((godot::StreamPeerWasm*)user)->put_partial_data(p_data, p_bytes, *r_sent); }
+    int _get_available_bytes(const void* user) { return ((godot::StreamPeerWasm*)user)->get_available_bytes(); }
+  #endif
 }
 
 namespace godot {
-  void StreamPeerWasm::_register_methods() {
-    register_method("seek", &StreamPeerWasm::seek);
-    register_method("get_position", &StreamPeerWasm::get_position);
+  void StreamPeerWasm::REGISTRATION_METHOD() {
+    #ifdef GODOT_MODULE
+      ClassDB::bind_method(D_METHOD("seek", "p_pos"), &StreamPeerWasm::seek);
+      ClassDB::bind_method(D_METHOD("get_position"), &StreamPeerWasm::get_position);
+    #else
+      register_method("seek", &StreamPeerWasm::seek);
+      register_method("get_position", &StreamPeerWasm::get_position);
+    #endif
   }
 
   StreamPeerWasm::StreamPeerWasm() {
-    interface = {
-      GDNATIVE_VERSION,
-      this,
-      &_get_data,
-      &_get_partial_data,
-      &_put_data,
-      &_put_partial_data,
-      &_get_available_bytes,
-      NULL
-    };
+    INTERFACE_DEFINE;
     pointer = 0;
     memory = NULL;
   }
@@ -35,7 +35,7 @@ namespace godot {
   StreamPeerWasm::~StreamPeerWasm() { }
 
   void StreamPeerWasm::_init() {
-    net_api->godot_net_bind_stream_peer(_owner, &interface);
+    INTERFACE_INIT;
   }
 
   Ref<StreamPeerWasm> StreamPeerWasm::seek(int p_pos) {
@@ -50,33 +50,33 @@ namespace godot {
   }
 
   godot_error StreamPeerWasm::get_data(uint8_t *p_buffer, int p_bytes) {
-    FAIL_IF(memory == NULL, "Invalid stream peer memory", GDERROR(ERR_INVALID_DATA));
+    FAIL_IF(memory == NULL, "Invalid stream peer memory", ERR_INVALID_DATA);
     byte_t* data = wasm_memory_data(memory) + pointer;
     memcpy(p_buffer, data, p_bytes);
     pointer += p_bytes;
-    return GDERROR(OK);
+    return OK;
   }
 
-  godot_error StreamPeerWasm::get_partial_data(uint8_t *p_buffer, int p_bytes, int *r_received) {
-    *r_received = p_bytes;
+  godot_error StreamPeerWasm::get_partial_data(uint8_t *p_buffer, int p_bytes, int &r_received) {
+    r_received = p_bytes;
     return get_data(p_buffer, p_bytes);
   }
 
   godot_error StreamPeerWasm::put_data(const uint8_t *p_data, int p_bytes) {
-    FAIL_IF(memory == NULL, "Invalid stream peer memory", GDERROR(ERR_INVALID_DATA));
-    if (p_bytes <= 0) return GDERROR(OK);
+    FAIL_IF(memory == NULL, "Invalid stream peer memory", ERR_INVALID_DATA);
+    if (p_bytes <= 0) return OK;
     byte_t* data = wasm_memory_data(memory) + pointer;
     memcpy(data, p_data, p_bytes);
     pointer += p_bytes;
-    return GDERROR(OK);
+    return OK;
   }
 
-  godot_error StreamPeerWasm::put_partial_data(const uint8_t *p_data, int p_bytes, int *r_sent) {
-    *r_sent = p_bytes;
+  godot_error StreamPeerWasm::put_partial_data(const uint8_t *p_data, int p_bytes, int &r_sent) {
+    r_sent = p_bytes;
     return put_data(p_data, p_bytes);
   }
 
-  int StreamPeerWasm::get_available_bytes() {
+  int StreamPeerWasm::get_available_bytes() const {
     return 0; // Not relevant
   }
 }

--- a/src/stream-peer-wasm.h
+++ b/src/stream-peer-wasm.h
@@ -22,11 +22,11 @@ namespace godot {
       wasm_memory_t* memory;
       Ref<StreamPeerWasm> seek(int p_pos);
       uint32_t get_position();
-      virtual godot_error get_data(uint8_t *p_buffer, int p_bytes);
-      virtual godot_error get_partial_data(uint8_t *p_buffer, int p_bytes, int *r_received);
-      virtual godot_error put_data(const uint8_t *p_data, int p_bytes);
-      virtual godot_error put_partial_data(const uint8_t *p_data, int p_bytes, int *r_sent);
-      virtual int get_available_bytes();
+      godot_error get_data(uint8_t *p_buffer, int p_bytes);
+      godot_error get_partial_data(uint8_t *p_buffer, int p_bytes, int *r_received);
+      godot_error put_data(const uint8_t *p_data, int p_bytes);
+      godot_error put_partial_data(const uint8_t *p_data, int p_bytes, int *r_sent);
+      int get_available_bytes() const;
   };
 }
 

--- a/src/stream-peer-wasm.h
+++ b/src/stream-peer-wasm.h
@@ -1,31 +1,40 @@
 #ifndef STREAM_PEER_WASM_H
 #define STREAM_PEER_WASM_H
 
-#include <Godot.hpp>
-#include <StreamPeerGDNative.hpp>
 #include "wasmer.h"
 #include "defs.h"
 
+namespace {
+  #ifdef GODOT_MODULE
+    #define SUPER_CLASS StreamPeer
+    #define INTERFACE_DECLARE
+  #else
+    #define SUPER_CLASS StreamPeerGDNative
+    #define INTERFACE_DECLARE godot_net_stream_peer interface
+  #endif
+}
+
 namespace godot {
-  class StreamPeerWasm : public StreamPeerGDNative {
-    GODOT_CLASS(StreamPeerWasm, StreamPeerGDNative)
+  class StreamPeerWasm : public SUPER_CLASS {
+    GDCLASS(StreamPeerWasm, SUPER_CLASS);
 
     private:
-      godot_net_stream_peer interface;
+      INTERFACE_DECLARE;
       uint32_t pointer;
 
     public:
-      static void _register_methods();
+      StreamPeerWasm* i;
+      static void REGISTRATION_METHOD();
       StreamPeerWasm();
       ~StreamPeerWasm();
       void _init();
       wasm_memory_t* memory;
       Ref<StreamPeerWasm> seek(int p_pos);
       uint32_t get_position();
-      godot_error get_data(uint8_t *p_buffer, int p_bytes);
-      godot_error get_partial_data(uint8_t *p_buffer, int p_bytes, int *r_received);
-      godot_error put_data(const uint8_t *p_data, int p_bytes);
-      godot_error put_partial_data(const uint8_t *p_data, int p_bytes, int *r_sent);
+      godot_error put_data(const uint8_t* p_data, int p_bytes);
+      godot_error put_partial_data(const uint8_t* p_data, int p_bytes, int& r_sent);
+      godot_error get_data(uint8_t* p_buffer, int p_bytes);
+      godot_error get_partial_data(uint8_t* p_buffer, int p_bytes, int& r_received);
       int get_available_bytes() const;
   };
 }


### PR DESCRIPTION
Adapted the project to compile as either an addon or module. Closes #7. Does not actually allow for web/HTML5 exports due to Wasmer not being able to be compiled to Wasm via Emscripten (which is what happens internally when compiling Godot export templates). More details in #18).

Surprisingly few compromises and defines were required. An overview of the quirks introduced:
1. `GODOT_MODULE` define determines how Godot sources are included. To make things easier, all Godot source includes should go in `defs.h`. While a little awkward, I think this is an okay pattern for the (currently) very limited imports used. If this proves problematic, could use the same pattern in each individual source file. Example:
    ```
    #ifdef GODOT_MODULE // Godot includes when building module
      #include "scene/2d/sprite.h"
    #else // Godot addon includes
      #include <Godot.hpp>
      #include <Sprite.hpp>
    #endif
    ```
1. Method are registered via `_bind_methods` in Godot and `_register_methods`. `REGISTRATION_METHOD` is used to abstract this difference. Inside the method, there's a check on the `GODOT_MODULE` define to actually register the methods differently. Example:
    ```
    void MyClass::REGISTRATION_METHOD() {
      #ifdef GODOT_MODULE
        ClassDB::bind_method(D_METHOD("my_method"), &MyClass::my_method);
      #else
        register_method("my_method", &MyClass::my_method);
      #endif
    }
    ```
1. `NS` define used to define the `godot::` namespace that is required for addon and blank (`::`) namespace for module.
1. `godot_error` (used in GDNative) is defined as an alias for `Error` for modules. 
1. Errors used by the addon are defined explicitly using the same name without the `godot_` prefix. This aligns error names with Godot proper (3.x and 4) _and_ GDExtension. For example, Godot and GDExtension use `OK` while GDNative uses `GODOT_OK`. Now an `OK` define exists to align GDNative with the others.
1. Superclass of StreamPeerWasm is now set by a define (either StreamPeer or StreamPeerGDNative). StreamPeerGDNative interface is all defines. This is hideous and will hopefully remain the ugliest part the addon/module agnosticism. 

To build the engine with the Godot Wasm module, add the entire project in `godot/modules/wasm` and run `scons platform=MY_PLATFORM`.

CC @Trey2k 