### PR TITLE
Extended WASI support

### DIFF
--- a/examples/wasm-consume/Main.gd
+++ b/examples/wasm-consume/Main.gd
@@ -1,6 +1,6 @@
 extends Control
 
-const info_template := "[b]Import Globals[/b]\n%s[b]Imports Functions[/b]\n%s[b]Export Globals[/b]\n%s[b]Export Functions[/b]\n%s[b]Memory[/b]\n[indent]Min %s\nMax %s%s[/indent]"
+const info_template := "[b]Import Globals[/b]\n%s[b]Imports Functions[/b]\n%s[b]Export Globals[/b]\n%s[b]Export Functions[/b]\n%s[b]Memory[/b]\n[indent]%s[/indent]"
 var callback_count: int
 @onready var wasm: Wasm = Wasm.new()
 
@@ -42,14 +42,16 @@ func _update_info():
 	if info.is_empty():
 		$"%InfoText".set("text", "Error")
 		return
+	var memory_info = ""
+	if info.has("memory_min"): memory_info += "\nMin %s" % _pretty_bytes(info.memory_min)
+	if info.has("memory_max"): memory_info += "\nMax %s" % _pretty_bytes(info.memory_max)
+	if info.has("memory_current"): memory_info += "\nCurrent %s" % _pretty_bytes(info.memory_current)
 	$"%InfoText".text = info_template % [
 		_pretty_signatures({}),
 		_pretty_signatures(info.import_functions),
 		_pretty_signatures(info.export_globals),
 		_pretty_signatures(info.export_functions),
-		_pretty_bytes(info.memory_min),
-		_pretty_bytes(info.memory_max),
-		"\nCurrent %s" % _pretty_bytes(info.memory_current) if "memory_current" in info else "",
+		memory_info,
 	]
 
 func _update_memory_type(index: int):

--- a/src/defs.h
+++ b/src/defs.h
@@ -2,9 +2,11 @@
 #define GODOT_WASM_DEFS_H
 
 #ifdef GODOT_MODULE // Godot includes when building module
+  #include "core/os/time.h"
   #include "core/io/stream_peer.h"
 #else // Godot addon includes
   #include "godot_cpp/classes/ref_counted.hpp"
+  #include "godot_cpp/classes/time.hpp"
   #include "godot_cpp/classes/stream_peer_extension.hpp"
   #include "godot_cpp/variant/utility_functions.hpp"
 #endif
@@ -24,6 +26,7 @@
 #define FAIL_IF(cond, message, ret) if (unlikely(cond)) FAIL(message, ret)
 #define INSTANTIATE_REF(ref) ref.instantiate()
 #define BYTE_ARRAY_POINTER(array) array.ptr()
+#define UNIX_TIME_NS Time::get_singleton()->get_unix_time_from_system() * 1000000000.0
 #define NULL_VARIANT Variant()
 #define PAGE_SIZE 65536
 

--- a/src/defs.h
+++ b/src/defs.h
@@ -3,10 +3,12 @@
 
 #ifdef GODOT_MODULE // Godot includes when building module
   #include "core/os/time.h"
+  #include "core/crypto/crypto.h"
   #include "core/io/stream_peer.h"
 #else // Godot addon includes
   #include "godot_cpp/classes/ref_counted.hpp"
   #include "godot_cpp/classes/time.hpp"
+  #include "godot_cpp/classes/crypto.hpp"
   #include "godot_cpp/classes/stream_peer_extension.hpp"
   #include "godot_cpp/variant/utility_functions.hpp"
 #endif
@@ -16,11 +18,13 @@
   #define PRINT(message) print_line(String(message))
   #define PRINT_ERROR(message) print_error("Godot Wasm: " + String(message))
   #define REGISTRATION_METHOD _bind_methods
+  #define RANDOM_BYTES(n) Crypto::create()->generate_random_bytes(n)
 #else
   #define PRINT(message) UtilityFunctions::print(String(message))
   #define PRINT_ERROR(message) _err_print_error(__FUNCTION__, __FILE__, __LINE__, "Godot Wasm: " + String(message))
   #define godot_error Error
   #define REGISTRATION_METHOD _bind_methods
+  #define RANDOM_BYTES(n) Crypto().generate_random_bytes(n)
 #endif
 #define FAIL(message, ret) do { PRINT_ERROR(message); return ret; } while (0)
 #define FAIL_IF(cond, message, ret) if (unlikely(cond)) FAIL(message, ret)

--- a/src/defs.h
+++ b/src/defs.h
@@ -33,7 +33,8 @@
 #define INSTANTIATE_REF(ref) ref.instantiate()
 #define BYTE_ARRAY_POINTER(array) array.ptr()
 #define CMDLINE_ARGS OS::get_singleton()->get_cmdline_user_args()
-#define UNIX_TIME_NS Time::get_singleton()->get_unix_time_from_system() * 1000000000.0
+#define TIME_REALTIME Time::get_singleton()->get_unix_time_from_system() * 1000000000
+#define TIME_MONOTONIC Time::get_singleton()->get_ticks_usec() * 1000
 #define NULL_VARIANT Variant()
 #define PAGE_SIZE 65536
 

--- a/src/defs.h
+++ b/src/defs.h
@@ -2,11 +2,13 @@
 #define GODOT_WASM_DEFS_H
 
 #ifdef GODOT_MODULE // Godot includes when building module
+  #include "core/os/os.h"
   #include "core/os/time.h"
   #include "core/crypto/crypto.h"
   #include "core/io/stream_peer.h"
 #else // Godot addon includes
   #include "godot_cpp/classes/ref_counted.hpp"
+  #include "godot_cpp/classes/os.hpp"
   #include "godot_cpp/classes/time.hpp"
   #include "godot_cpp/classes/crypto.hpp"
   #include "godot_cpp/classes/stream_peer_extension.hpp"
@@ -30,6 +32,7 @@
 #define FAIL_IF(cond, message, ret) if (unlikely(cond)) FAIL(message, ret)
 #define INSTANTIATE_REF(ref) ref.instantiate()
 #define BYTE_ARRAY_POINTER(array) array.ptr()
+#define CMDLINE_ARGS OS::get_singleton()->get_cmdline_user_args()
 #define UNIX_TIME_NS Time::get_singleton()->get_unix_time_from_system() * 1000000000.0
 #define NULL_VARIANT Variant()
 #define PAGE_SIZE 65536

--- a/src/godot-wasm.cpp
+++ b/src/godot-wasm.cpp
@@ -191,8 +191,10 @@ namespace godot {
   }
 
   void Wasm::reset() {
-    module = NULL;
+    // TODO: Use nullptr
+    // TODO: Free memory
     instance = NULL;
+    module = NULL;
     memory_index = -1;
     stream->memory = NULL;
     import_funcs.clear();

--- a/src/godot-wasm.cpp
+++ b/src/godot-wasm.cpp
@@ -136,7 +136,7 @@ namespace godot {
       // TODO: Ensure target is valid and has method
       Variant variant = context->target->callv(context->method, params);
       godot_error error = extract_results(variant, results);
-      if (error) FAIL("Extracting import function results failed", trap("Extracting import function results failed"));
+      if (error) FAIL("Extracting import function results failed", trap("Extracting import function results failed\0"));
       return NULL;
     }
   }

--- a/src/godot-wasm.h
+++ b/src/godot-wasm.h
@@ -20,7 +20,7 @@ namespace godot {
       wasm_store_t* store;
       wasm_module_t* module;
       wasm_instance_t* instance;
-      uint16_t memory_index;
+      int32_t memory_index;
       Dictionary permissions;
       Ref<StreamPeerWasm> stream;
       std::map<String, godot_wasm::context_callback> import_funcs;

--- a/src/godot-wasm.h
+++ b/src/godot-wasm.h
@@ -21,9 +21,12 @@ namespace godot {
       wasm_module_t* module;
       wasm_instance_t* instance;
       uint16_t memory_index;
+      Dictionary permissions;
+      Ref<StreamPeerWasm> stream;
       std::map<String, godot_wasm::context_callback> import_funcs;
       std::map<String, godot_wasm::context_extern> export_globals;
       std::map<String, godot_wasm::context_extern> export_funcs;
+      void reset();
       godot_error map_names();
       wasm_func_t* create_callback(godot_wasm::context_callback* context);
 
@@ -40,8 +43,10 @@ namespace godot {
       Variant function(String name, Array args) const;
       Variant global(String name) const;
       uint64_t mem_size() const;
-      Ref<StreamPeerWasm> stream;
       Ref<StreamPeerWasm> get_stream() const;
+      void set_permissions(const Dictionary &update);
+      Dictionary get_permissions() const;
+      bool has_permission(String permission) const;
   };
 }
 

--- a/src/wasi-shim.cpp
+++ b/src/wasi-shim.cpp
@@ -6,6 +6,7 @@
 // See https://github.com/WebAssembly/wasi-libc/blob/main/libc-bottom-half/headers/public/wasi/api.h
 #define __WASI_ERRNO_SUCCESS (UINT16_C(0))
 #define __WASI_ERRNO_ACCES (UINT16_C(2))
+#define __WASI_ERRNO_INVAL (UINT16_C(28))
 
 namespace godot {
   namespace {
@@ -64,7 +65,7 @@ namespace godot {
 
     // WASI fd_write: [I32, I32, I32, I32] -> [I32]
     wasm_trap_t* wasi_fd_write(void* env, const wasm_val_vec_t* args, wasm_val_vec_t* results) {
-      FAIL_IF(args->size != 4 || results->size != 1, "Invalid call WASI fd_write", NULL);
+      FAIL_IF(args->size != 4 || results->size != 1, "Invalid arguments fd_write", wasi_result(results, __WASI_ERRNO_INVAL, "Invalid arguments\0"));
       Wasm* wasm = (Wasm*)env;
       byte_t* data = wasm_memory_data(wasm->get_stream().ptr()->memory);
       int32_t fd = args->data[0].of.i32;
@@ -85,7 +86,7 @@ namespace godot {
 
     // WASI proc_exit: [I32] -> []
     wasm_trap_t* wasi_proc_exit(void* env, const wasm_val_vec_t* args, wasm_val_vec_t* results) {
-      FAIL_IF(args->size != 1 || results->size != 0, "Invalid call WASI proc_exit", NULL);
+      FAIL_IF(args->size != 1 || results->size != 0, "Invalid arguments proc_exit", wasi_result(results, __WASI_ERRNO_INVAL, "Invalid arguments\0"));
       Wasm* wasm = (Wasm*)env;
       wasm->exit(args->data[0].of.i32);
       return NULL;
@@ -93,7 +94,7 @@ namespace godot {
 
     // WASI args_sizes_get: [I32, I32] -> [I32]
     wasm_trap_t* wasi_args_sizes_get(void* env, const wasm_val_vec_t* args, wasm_val_vec_t* results) {
-      FAIL_IF(args->size != 2 || results->size != 1, "Invalid call WASI args_sizes_get", NULL);
+      FAIL_IF(args->size != 2 || results->size != 1, "Invalid arguments args_sizes_get", wasi_result(results, __WASI_ERRNO_INVAL, "Invalid arguments\0"));
       Wasm* wasm = (Wasm*)env;
       byte_t* data = wasm_memory_data(wasm->get_stream().ptr()->memory);
       int32_t offset_count = args->data[0].of.i32;
@@ -106,7 +107,7 @@ namespace godot {
 
     // WASI args_get: [I32, I32] -> [I32]
     wasm_trap_t* wasi_args_get(void* env, const wasm_val_vec_t* args, wasm_val_vec_t* results) {
-      FAIL_IF(args->size != 2 || results->size != 1, "Invalid call WASI args_get", NULL);
+      FAIL_IF(args->size != 2 || results->size != 1, "Invalid arguments args_get", wasi_result(results, __WASI_ERRNO_INVAL, "Invalid arguments\0"));
       Wasm* wasm = (Wasm*)env;
       byte_t* data = wasm_memory_data(wasm->get_stream().ptr()->memory);
       int32_t offset_environ = args->data[0].of.i32;
@@ -124,7 +125,7 @@ namespace godot {
 
     // WASI environ_sizes_get: [I32, I32] -> [I32]
     wasm_trap_t* wasi_environ_sizes_get(void* env, const wasm_val_vec_t* args, wasm_val_vec_t* results) {
-      FAIL_IF(args->size != 2 || results->size != 1, "Invalid call WASI environ_sizes_get", NULL);
+      FAIL_IF(args->size != 2 || results->size != 1, "Invalid arguments environ_sizes_get", wasi_result(results, __WASI_ERRNO_INVAL, "Invalid arguments\0"));
       Wasm* wasm = (Wasm*)env;
       byte_t* data = wasm_memory_data(wasm->get_stream().ptr()->memory);
       int32_t offset_count = args->data[0].of.i32;
@@ -137,13 +138,13 @@ namespace godot {
 
     // WASI environ_get: [I32, I32] -> [I32]
     wasm_trap_t* wasi_environ_get(void* env, const wasm_val_vec_t* args, wasm_val_vec_t* results) {
-      FAIL_IF(args->size != 2 || results->size != 1, "Invalid call WASI environ_get", NULL);
+      FAIL_IF(args->size != 2 || results->size != 1, "Invalid arguments environ_get", wasi_result(results, __WASI_ERRNO_INVAL, "Invalid arguments\0"));
       return wasi_result(results);
     }
 
     // WASI random_get: [I32, I32] -> [I32]
     wasm_trap_t* wasi_random_get(void* env, const wasm_val_vec_t* args, wasm_val_vec_t* results) {
-      FAIL_IF(args->size != 2 || results->size != 1, "Invalid call WASI random_get", NULL);
+      FAIL_IF(args->size != 2 || results->size != 1, "Invalid arguments random_get", wasi_result(results, __WASI_ERRNO_INVAL, "Invalid arguments\0"));
       Wasm* wasm = (Wasm*)env;
       byte_t* data = wasm_memory_data(wasm->get_stream().ptr()->memory);
       int32_t offset = args->data[0].of.i32;
@@ -155,7 +156,7 @@ namespace godot {
 
     // WASI clock_time_get: [I32, I64, I32] -> [I32]
     wasm_trap_t* wasi_clock_time_get(void* env, const wasm_val_vec_t* args, wasm_val_vec_t* results) {
-      FAIL_IF(args->size != 3 || results->size != 1, "Invalid call WASI clock_time_get", NULL);
+      FAIL_IF(args->size != 3 || results->size != 1, "Invalid arguments clock_time_get", wasi_result(results, __WASI_ERRNO_INVAL, "Invalid arguments\0"));
       Wasm* wasm = (Wasm*)env;
       byte_t* data = wasm_memory_data(wasm->get_stream().ptr()->memory);
       int32_t offset = args->data[2].of.i32;

--- a/src/wasi-shim.cpp
+++ b/src/wasi-shim.cpp
@@ -37,11 +37,11 @@ namespace godot {
       for (auto i = 0; i < args.size(); i++) {
         String s = args[i];
         if (!s.begins_with("--")) { // Invalid; may be value for previous key
-          if (incomplete.is_empty()) continue; // Ignore garbage
+          if (incomplete == "") continue; // Ignore garbage
           s = incomplete + "=" + s; // Value for previous key
           incomplete = ""; // Reset incomplete key value pair
         } else { // Valid key or key value pair
-          s = s.lstrip("--"); // Just key or key=value
+          s = s.substr(2, -1); // Just key or key=value
           auto parts = s.split("=");
           if (parts.size() < 2) { // Incomplete; may have subsequent value
             incomplete = s;

--- a/src/wasi-shim.cpp
+++ b/src/wasi-shim.cpp
@@ -1,4 +1,5 @@
 #include <string>
+#include <vector>
 #include <map>
 #include "wasi-shim.h"
 #include "godot-wasm.h"

--- a/src/wasi-shim.cpp
+++ b/src/wasi-shim.cpp
@@ -48,6 +48,19 @@ namespace godot {
       return NULL;
     }
 
+    // WASI clock_time_get: [I32, I64, I32] -> [I32]
+    wasm_trap_t* wasi_clock_time_get(void* env, const wasm_val_vec_t* args, wasm_val_vec_t* results) {
+      FAIL_IF(args->size != 3 || results->size != 1, "Invalid call WASI clock_time_get", NULL);
+      Wasm* wasm = (Wasm*)env;
+      byte_t* data = wasm_memory_data(wasm->stream.ptr()->memory);
+      int32_t offset = args->data[2].of.i32;
+      int64_t t = UNIX_TIME_NS;
+      memcpy(data + offset, &t, sizeof(t));
+      results->data[0].kind = WASM_I32;
+      results->data[0].of.i32 = 0;
+      return NULL;
+    }
+
     godot_wasm::wasi_callback wasi_factory_factory(const std::vector<wasm_valkind_enum> p_kinds, const std::vector<wasm_valkind_enum> r_kinds, wasm_func_callback_with_env_t c) {
       auto p_types = new std::vector<wasm_valtype_t*>;
       auto r_types = new std::vector<wasm_valtype_t*>;
@@ -62,6 +75,7 @@ namespace godot {
     std::map<std::string, godot_wasm::wasi_callback> factories {
       { "wasi_snapshot_preview1.fd_write", wasi_factory_factory({WASM_I32, WASM_I32, WASM_I32, WASM_I32}, {WASM_I32}, wasi_fd_write) },
       { "wasi_snapshot_preview1.proc_exit", wasi_factory_factory({WASM_I32}, {}, wasi_proc_exit) },
+      { "wasi_snapshot_preview1.clock_time_get", wasi_factory_factory({WASM_I32, WASM_I64, WASM_I32}, {WASM_I32}, wasi_clock_time_get) },
     };
   }
 

--- a/src/wasi-shim.cpp
+++ b/src/wasi-shim.cpp
@@ -48,6 +48,29 @@ namespace godot {
       return NULL;
     }
 
+    // WASI environ_sizes_get: [I32, I32] -> [I32]
+    wasm_trap_t* wasi_environ_sizes_get(void* env, const wasm_val_vec_t* args, wasm_val_vec_t* results) {
+      FAIL_IF(args->size != 2 || results->size != 1, "Invalid call WASI environ_sizes_get", NULL);
+      Wasm* wasm = (Wasm*)env;
+      byte_t* data = wasm_memory_data(wasm->stream.ptr()->memory);
+      int32_t offset_count = args->data[0].of.i32;
+      int32_t offset_length = args->data[1].of.i32;
+      int32_t zero = 0;
+      memcpy(data + offset_count, &zero, sizeof(int32_t));
+      memcpy(data + offset_length, &zero, sizeof(int32_t));
+      results->data[0].kind = WASM_I32;
+      results->data[0].of.i32 = 0;
+      return NULL;
+    }
+
+    // WASI environ_get: [I32, I32] -> [I32]
+    wasm_trap_t* wasi_environ_get(void* env, const wasm_val_vec_t* args, wasm_val_vec_t* results) {
+      FAIL_IF(args->size != 2 || results->size != 1, "Invalid call WASI environ_get", NULL);
+      results->data[0].kind = WASM_I32;
+      results->data[0].of.i32 = 0;
+      return NULL;
+    }
+
     // WASI random_get: [I32, I32] -> [I32]
     wasm_trap_t* wasi_random_get(void* env, const wasm_val_vec_t* args, wasm_val_vec_t* results) {
       FAIL_IF(args->size != 2 || results->size != 1, "Invalid call WASI random_get", NULL);
@@ -89,6 +112,8 @@ namespace godot {
     std::map<std::string, godot_wasm::wasi_callback> factories {
       { "wasi_snapshot_preview1.fd_write", wasi_factory_factory({WASM_I32, WASM_I32, WASM_I32, WASM_I32}, {WASM_I32}, wasi_fd_write) },
       { "wasi_snapshot_preview1.proc_exit", wasi_factory_factory({WASM_I32}, {}, wasi_proc_exit) },
+      { "wasi_snapshot_preview1.environ_sizes_get", wasi_factory_factory({WASM_I32, WASM_I32}, {WASM_I32}, wasi_environ_sizes_get) },
+      { "wasi_snapshot_preview1.environ_get", wasi_factory_factory({WASM_I32, WASM_I32}, {WASM_I32}, wasi_environ_get) },
       { "wasi_snapshot_preview1.random_get", wasi_factory_factory({WASM_I32, WASM_I32}, {WASM_I32}, wasi_random_get) },
       { "wasi_snapshot_preview1.clock_time_get", wasi_factory_factory({WASM_I32, WASM_I64, WASM_I32}, {WASM_I32}, wasi_clock_time_get) },
     };

--- a/src/wasi-shim.cpp
+++ b/src/wasi-shim.cpp
@@ -48,6 +48,20 @@ namespace godot {
       return NULL;
     }
 
+    // WASI random_get: [I32, I32] -> [I32]
+    wasm_trap_t* wasi_random_get(void* env, const wasm_val_vec_t* args, wasm_val_vec_t* results) {
+      FAIL_IF(args->size != 2 || results->size != 1, "Invalid call WASI random_get", NULL);
+      Wasm* wasm = (Wasm*)env;
+      byte_t* data = wasm_memory_data(wasm->stream.ptr()->memory);
+      int32_t offset = args->data[0].of.i32;
+      int32_t length = args->data[1].of.i32;
+      PackedByteArray bytes = RANDOM_BYTES(length);
+      memcpy(data + offset, BYTE_ARRAY_POINTER(bytes), length);
+      results->data[0].kind = WASM_I32;
+      results->data[0].of.i32 = 0;
+      return NULL;
+    }
+
     // WASI clock_time_get: [I32, I64, I32] -> [I32]
     wasm_trap_t* wasi_clock_time_get(void* env, const wasm_val_vec_t* args, wasm_val_vec_t* results) {
       FAIL_IF(args->size != 3 || results->size != 1, "Invalid call WASI clock_time_get", NULL);
@@ -75,6 +89,7 @@ namespace godot {
     std::map<std::string, godot_wasm::wasi_callback> factories {
       { "wasi_snapshot_preview1.fd_write", wasi_factory_factory({WASM_I32, WASM_I32, WASM_I32, WASM_I32}, {WASM_I32}, wasi_fd_write) },
       { "wasi_snapshot_preview1.proc_exit", wasi_factory_factory({WASM_I32}, {}, wasi_proc_exit) },
+      { "wasi_snapshot_preview1.random_get", wasi_factory_factory({WASM_I32, WASM_I32}, {WASM_I32}, wasi_random_get) },
       { "wasi_snapshot_preview1.clock_time_get", wasi_factory_factory({WASM_I32, WASM_I64, WASM_I32}, {WASM_I32}, wasi_clock_time_get) },
     };
   }

--- a/src/wasi-shim.cpp
+++ b/src/wasi-shim.cpp
@@ -66,14 +66,14 @@ namespace godot {
     wasm_trap_t* wasi_fd_write(void* env, const wasm_val_vec_t* args, wasm_val_vec_t* results) {
       FAIL_IF(args->size != 4 || results->size != 1, "Invalid call WASI fd_write", NULL);
       Wasm* wasm = (Wasm*)env;
-      byte_t* data = wasm_memory_data(wasm->stream.ptr()->memory);
+      byte_t* data = wasm_memory_data(wasm->get_stream().ptr()->memory);
       int32_t fd = args->data[0].of.i32;
       int32_t offset_iov = args->data[1].of.i32;
       int32_t count_iov = args->data[2].of.i32;
       int32_t offset_written = args->data[3].of.i32;
       uint32_t written = 0;
       for (auto i = 0; i < count_iov; i++) {
-        wasi_io_vector iov = get_io_vector(wasm->stream.ptr()->memory, offset_iov, i);
+        wasi_io_vector iov = get_io_vector(wasm->get_stream().ptr()->memory, offset_iov, i);
         std::string message = std::string(data + iov.offset, data + iov.offset + iov.length);
         if (iov.length == 1 && message == "\u000A") continue; // Skip line feed
         fd == 1 ? PRINT(message.c_str()) : PRINT_ERROR(message.c_str());
@@ -95,7 +95,7 @@ namespace godot {
     wasm_trap_t* wasi_args_sizes_get(void* env, const wasm_val_vec_t* args, wasm_val_vec_t* results) {
       FAIL_IF(args->size != 2 || results->size != 1, "Invalid call WASI args_sizes_get", NULL);
       Wasm* wasm = (Wasm*)env;
-      byte_t* data = wasm_memory_data(wasm->stream.ptr()->memory);
+      byte_t* data = wasm_memory_data(wasm->get_stream().ptr()->memory);
       int32_t offset_count = args->data[0].of.i32;
       int32_t offset_length = args->data[1].of.i32;
       wasi_encoded_strings encoded = encode_args(CMDLINE_ARGS);
@@ -108,7 +108,7 @@ namespace godot {
     wasm_trap_t* wasi_args_get(void* env, const wasm_val_vec_t* args, wasm_val_vec_t* results) {
       FAIL_IF(args->size != 2 || results->size != 1, "Invalid call WASI args_get", NULL);
       Wasm* wasm = (Wasm*)env;
-      byte_t* data = wasm_memory_data(wasm->stream.ptr()->memory);
+      byte_t* data = wasm_memory_data(wasm->get_stream().ptr()->memory);
       int32_t offset_environ = args->data[0].of.i32;
       int32_t offset_buffer = args->data[1].of.i32;
       wasi_encoded_strings encoded = encode_args(CMDLINE_ARGS);
@@ -126,7 +126,7 @@ namespace godot {
     wasm_trap_t* wasi_environ_sizes_get(void* env, const wasm_val_vec_t* args, wasm_val_vec_t* results) {
       FAIL_IF(args->size != 2 || results->size != 1, "Invalid call WASI environ_sizes_get", NULL);
       Wasm* wasm = (Wasm*)env;
-      byte_t* data = wasm_memory_data(wasm->stream.ptr()->memory);
+      byte_t* data = wasm_memory_data(wasm->get_stream().ptr()->memory);
       int32_t offset_count = args->data[0].of.i32;
       int32_t offset_length = args->data[1].of.i32;
       int32_t zero = 0;
@@ -145,7 +145,7 @@ namespace godot {
     wasm_trap_t* wasi_random_get(void* env, const wasm_val_vec_t* args, wasm_val_vec_t* results) {
       FAIL_IF(args->size != 2 || results->size != 1, "Invalid call WASI random_get", NULL);
       Wasm* wasm = (Wasm*)env;
-      byte_t* data = wasm_memory_data(wasm->stream.ptr()->memory);
+      byte_t* data = wasm_memory_data(wasm->get_stream().ptr()->memory);
       int32_t offset = args->data[0].of.i32;
       int32_t length = args->data[1].of.i32;
       PackedByteArray bytes = RANDOM_BYTES(length);
@@ -157,7 +157,7 @@ namespace godot {
     wasm_trap_t* wasi_clock_time_get(void* env, const wasm_val_vec_t* args, wasm_val_vec_t* results) {
       FAIL_IF(args->size != 3 || results->size != 1, "Invalid call WASI clock_time_get", NULL);
       Wasm* wasm = (Wasm*)env;
-      byte_t* data = wasm_memory_data(wasm->stream.ptr()->memory);
+      byte_t* data = wasm_memory_data(wasm->get_stream().ptr()->memory);
       int32_t offset = args->data[2].of.i32;
       int64_t t = UNIX_TIME_NS;
       memcpy(data + offset, &t, sizeof(t));

--- a/src/wasi-shim.cpp
+++ b/src/wasi-shim.cpp
@@ -67,6 +67,7 @@ namespace godot {
     wasm_trap_t* wasi_fd_write(void* env, const wasm_val_vec_t* args, wasm_val_vec_t* results) {
       FAIL_IF(args->size != 4 || results->size != 1, "Invalid arguments fd_write", wasi_result(results, __WASI_ERRNO_INVAL, "Invalid arguments\0"));
       Wasm* wasm = (Wasm*)env;
+      if (!wasm->has_permission("print")) return wasi_result(results, __WASI_ERRNO_ACCES, "Not permitted\0");
       byte_t* data = wasm_memory_data(wasm->get_stream().ptr()->memory);
       int32_t fd = args->data[0].of.i32;
       int32_t offset_iov = args->data[1].of.i32;
@@ -88,6 +89,7 @@ namespace godot {
     wasm_trap_t* wasi_proc_exit(void* env, const wasm_val_vec_t* args, wasm_val_vec_t* results) {
       FAIL_IF(args->size != 1 || results->size != 0, "Invalid arguments proc_exit", wasi_result(results, __WASI_ERRNO_INVAL, "Invalid arguments\0"));
       Wasm* wasm = (Wasm*)env;
+      if (!wasm->has_permission("exit")) return wasi_result(results, __WASI_ERRNO_ACCES, "Not permitted\0");
       wasm->exit(args->data[0].of.i32);
       return NULL;
     }
@@ -96,6 +98,7 @@ namespace godot {
     wasm_trap_t* wasi_args_sizes_get(void* env, const wasm_val_vec_t* args, wasm_val_vec_t* results) {
       FAIL_IF(args->size != 2 || results->size != 1, "Invalid arguments args_sizes_get", wasi_result(results, __WASI_ERRNO_INVAL, "Invalid arguments\0"));
       Wasm* wasm = (Wasm*)env;
+      if (!wasm->has_permission("args")) return wasi_result(results, __WASI_ERRNO_ACCES, "Not permitted\0");
       byte_t* data = wasm_memory_data(wasm->get_stream().ptr()->memory);
       int32_t offset_count = args->data[0].of.i32;
       int32_t offset_length = args->data[1].of.i32;
@@ -109,6 +112,7 @@ namespace godot {
     wasm_trap_t* wasi_args_get(void* env, const wasm_val_vec_t* args, wasm_val_vec_t* results) {
       FAIL_IF(args->size != 2 || results->size != 1, "Invalid arguments args_get", wasi_result(results, __WASI_ERRNO_INVAL, "Invalid arguments\0"));
       Wasm* wasm = (Wasm*)env;
+      if (!wasm->has_permission("args")) return wasi_result(results, __WASI_ERRNO_ACCES, "Not permitted\0");
       byte_t* data = wasm_memory_data(wasm->get_stream().ptr()->memory);
       int32_t offset_environ = args->data[0].of.i32;
       int32_t offset_buffer = args->data[1].of.i32;
@@ -146,6 +150,7 @@ namespace godot {
     wasm_trap_t* wasi_random_get(void* env, const wasm_val_vec_t* args, wasm_val_vec_t* results) {
       FAIL_IF(args->size != 2 || results->size != 1, "Invalid arguments random_get", wasi_result(results, __WASI_ERRNO_INVAL, "Invalid arguments\0"));
       Wasm* wasm = (Wasm*)env;
+      if (!wasm->has_permission("random")) return wasi_result(results, __WASI_ERRNO_ACCES, "Not permitted\0");
       byte_t* data = wasm_memory_data(wasm->get_stream().ptr()->memory);
       int32_t offset = args->data[0].of.i32;
       int32_t length = args->data[1].of.i32;
@@ -158,6 +163,7 @@ namespace godot {
     wasm_trap_t* wasi_clock_time_get(void* env, const wasm_val_vec_t* args, wasm_val_vec_t* results) {
       FAIL_IF(args->size != 3 || results->size != 1, "Invalid arguments clock_time_get", wasi_result(results, __WASI_ERRNO_INVAL, "Invalid arguments\0"));
       Wasm* wasm = (Wasm*)env;
+      if (!wasm->has_permission("time")) return wasi_result(results, __WASI_ERRNO_ACCES, "Not permitted\0");
       byte_t* data = wasm_memory_data(wasm->get_stream().ptr()->memory);
       int32_t offset = args->data[2].of.i32;
       int64_t t = UNIX_TIME_NS;

--- a/src/wasi-shim.cpp
+++ b/src/wasi-shim.cpp
@@ -7,6 +7,8 @@
 #define __WASI_ERRNO_SUCCESS (UINT16_C(0))
 #define __WASI_ERRNO_ACCES (UINT16_C(2))
 #define __WASI_ERRNO_INVAL (UINT16_C(28))
+#define __WASI_CLOCKID_REALTIME (UINT32_C(0))
+#define __WASI_CLOCKID_MONOTONIC (UINT32_C(1))
 
 namespace godot {
   namespace {
@@ -165,8 +167,9 @@ namespace godot {
       Wasm* wasm = (Wasm*)env;
       if (!wasm->has_permission("time")) return wasi_result(results, __WASI_ERRNO_ACCES, "Not permitted\0");
       byte_t* data = wasm_memory_data(wasm->get_stream().ptr()->memory);
+      int32_t clock_id = args->data[0].of.i32;
       int32_t offset = args->data[2].of.i32;
-      int64_t t = UNIX_TIME_NS;
+      int64_t t = clock_id == __WASI_CLOCKID_REALTIME ? TIME_REALTIME : TIME_MONOTONIC;
       memcpy(data + offset, &t, sizeof(t));
       return wasi_result(results);
     }


### PR DESCRIPTION
Includes a simple permissions model and the following WASI support.
- `wasi_snapshot_preview1.args_sizes_get`
- `wasi_snapshot_preview1.args_get`
- `wasi_snapshot_preview1.environ_sizes_get`
- `wasi_snapshot_preview1.environ_get`
- `wasi_snapshot_preview1.random_get`
- `wasi_snapshot_preview1.clock_time_get`

All bindings defer to Godot's implementation of required functionality. For example, using `wasi_snapshot_preview1.random_get`, a random buffer is filled with Godot's [`Crypto.generate_random_bytes()`](https://docs.godotengine.org/en/stable/classes/class_crypto.html#class-crypto-method-generate-random-bytes), system time requested by `wasi_snapshot_preview1.clock_time_get` uses [`Time.get_unix_time_from_system()`](https://docs.godotengine.org/en/stable/classes/class_time.html#class-time-method-get-unix-time-from-system), `wasi_snapshot_preview1.args_get` uses [`OS.get_cmdline_user_args()`](https://docs.godotengine.org/en/stable/classes/class_os.html#class-os-method-get-cmdline-user-args).

Permissions can be set via `Wasm.set_permssions()`. This lays the groundwork for more impactful WASI behaviour e.g. filesystem access.

Todo:
- [ ] Update docs to capture permission settings.
- [ ] Update README with WASI defaults.
- [ ] Deny WASI behaviour without killing module. It seems AssemblyScript and Grain kill the module if an error is returned from `wasi_snapshot_preview1:fd_write`. Currently returning [`__WASI_ERRNO_ACCES`](https://github.com/WebAssembly/wasi-libc/blob/main/libc-bottom-half/headers/public/wasi/api.h#L123)[sic].