### PR TITLE
Support Wasmtime runtime

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,6 +2,7 @@
 .vscode/
 .sconsign.dblite
 wasmer/
+wasmtime/
 addons.zip
 *.os
 *.obj

--- a/README.md
+++ b/README.md
@@ -1,9 +1,7 @@
 # Godot Wasm
 
 <p align="center">
-  <a href="https://wasmer.io" target="_blank" rel="noopener noreferrer">
-    <img width="200" src="https://raw.githubusercontent.com/ashtonmeuser/godot-wasm/master/media/Icon.png" alt="Wasmer logo">
-  </a>
+  <img width="200" src="https://raw.githubusercontent.com/ashtonmeuser/godot-wasm/master/media/Icon.png" alt="Godot Wasm Logo">
 </p>
 <p align="center">
   <a href="https://github.com/ashtonmeuser/godot-wasm/actions/workflows/addon.yml">
@@ -20,7 +18,7 @@
 > **Warning**
 > This project is still in its infancy. Interfaces are liable to change with each release until v1.0.
 
-A Godot extension allowing for loading and interacting with [WebAssembly (Wasm)](https://webassembly.org) modules from GDScript via the [Wasmer](https://wasmer.io) WebAssembly runtime.
+A Godot extension allowing for loading and interacting with [WebAssembly (Wasm)](https://webassembly.org) modules from GDScript via the [Wasmer](https://wasmer.io) and [Wasmtime](https://wasmtime.dev) WebAssembly runtimes.
 
 ## Documentation
 

--- a/SConstruct
+++ b/SConstruct
@@ -1,29 +1,31 @@
 #!python
-import os
-from utils import download_wasmer, VERSION_DEFAULT
+from utils import download_wasmer, download_wasmtime, WASMER_VER_DEFAULT, WASMTIME_VER_DEFAULT
 
 # Initial options inheriting from CLI args
 opts = Variables([], ARGUMENTS)
 
 # Define options
 opts.Add(EnumVariable("wasm_runtime", "Wasm runtime used", "wasmer", ["wasmer", "wasmtime"]))
-opts.Add(BoolVariable("download_wasmer", "Download Wasmer library", "no"))
-opts.Add("wasmer_version", "Wasmer library version", VERSION_DEFAULT)
+opts.Add(BoolVariable("download_runtime", "(Re)download runtime library", "no"))
+opts.Add("runtime_version", "Runtime library version", None)
 
 # SConstruct environment from Godot CPP
 env = SConscript("godot-cpp/SConstruct")
 opts.Update(env)
 
-# Download Wasmer if required
-download_wasmer(env, env["download_wasmer"], env["wasmer_version"])
+# Download runtime if required
+if env["wasm_runtime"] == "wasmer":
+    download_wasmer(env, env["download_runtime"], env.get("runtime_version", WASMER_VER_DEFAULT))
+elif env["wasm_runtime"] == "wasmtime":
+    download_wasmtime(env, env["download_runtime"], env.get("runtime_version", WASMTIME_VER_DEFAULT))
 
 # Check platform specifics
 if env["platform"] == "windows":
     if env.get("use_mingw"):  # MinGW
-        env["LIBWASMERSUFFIX"] = ".a"
+        env["LIBRUNTIMESUFFIX"] = ".a"
         env.Append(LIBS=["userenv"])
     else:  # MSVC
-        env["LIBWASMERSUFFIX"] = ".lib"
+        env["LIBRUNTIMESUFFIX"] = ".lib"
         # Force Windows SDK library suffix (see https://github.com/godotengine/godot/issues/23687)
         env.Append(LINKFLAGS=["bcrypt.lib", "userenv.lib", "ws2_32.lib", "advapi32.lib"])
 
@@ -35,7 +37,7 @@ runtime_lib = env.File(
     "{runtime}/lib/{prefix}{runtime}{suffix}".format(
         runtime=env["wasm_runtime"],
         prefix=env["LIBPREFIX"],
-        suffix=env.get("LIBWASMERSUFFIX", env["LIBSUFFIX"]),
+        suffix=env.get("LIBRUNTIMESUFFIX", env["LIBSUFFIX"]),
     )
 )
 

--- a/SConstruct
+++ b/SConstruct
@@ -6,6 +6,7 @@ from utils import download_wasmer, VERSION_DEFAULT
 opts = Variables([], ARGUMENTS)
 
 # Define options
+opts.Add(EnumVariable("wasm_runtime", "Wasm runtime used", "wasmer", ["wasmer", "wasmtime"]))
 opts.Add(BoolVariable("download_wasmer", "Download Wasmer library", "no"))
 opts.Add("wasmer_version", "Wasmer library version", VERSION_DEFAULT)
 
@@ -30,11 +31,17 @@ if env["platform"] == "windows":
 env.Append(CPPDEFINES=["GDEXTENSION"])
 
 # Explicit static libraries
-wasmer_lib = env.File("wasmer/lib/{}wasmer{}".format(env["LIBPREFIX"], env.get("LIBWASMERSUFFIX", env["LIBSUFFIX"])))
+runtime_lib = env.File(
+    "{runtime}/lib/{prefix}{runtime}{suffix}".format(
+        runtime=env["wasm_runtime"],
+        prefix=env["LIBPREFIX"],
+        suffix=env.get("LIBWASMERSUFFIX", env["LIBSUFFIX"]),
+    )
+)
 
 # CPP includes and libraries
-env.Append(CPPPATH=[".", "wasmer/include"])
-env.Append(LIBS=[wasmer_lib])
+env.Append(CPPPATH=[".", "{}/include".format(env["wasm_runtime"])])
+env.Append(LIBS=[runtime_lib])
 
 # Godot Wasm sources
 source = ["register_types.cpp", env.Glob("src/*.cpp")]

--- a/SCsub
+++ b/SCsub
@@ -1,47 +1,50 @@
-from utils import download_wasmer, VERSION_DEFAULT
+from utils import download_wasmer, download_wasmtime, WASMER_VER_DEFAULT, WASMTIME_VER_DEFAULT
 
 opts = Variables([], ARGUMENTS)
 
 opts.Add(EnumVariable("wasm_runtime", "Wasm runtime used", "wasmer", ["wasmer", "wasmtime"]))
-opts.Add(BoolVariable("download_wasmer", "Download Wasmer library", "no"))
-opts.Add("wasmer_version", "Wasmer library version", VERSION_DEFAULT)
+opts.Add(BoolVariable("download_runtime", "(Re)download runtime library", "no"))
+opts.Add("runtime_version", "Runtime library version", None)
 
 # Import env and create module-specific clone
 Import("env")
 module_env = env.Clone()
 opts.Update(module_env)
 
-# Download Wasmer if required
-download_wasmer(env, module_env["download_wasmer"], module_env["wasmer_version"])
+# Download runtime if required
+if module_env["wasm_runtime"] == "wasmer":
+    download_wasmer(env, module_env["download_runtime"], module_env.get("runtime_version", WASMER_VER_DEFAULT))
+elif module_env["wasm_runtime"] == "wasmtime":
+    download_wasmtime(env, module_env["download_runtime"], module_env.get("runtime_version", WASMTIME_VER_DEFAULT))
 
 # Check platform specifics
 if env["platform"] in ["linux", "linuxbsd", "x11"]:
-    env["LIBWASMERSUFFIX"] = ".a"
+    env["LIBRUNTIMESUFFIX"] = ".a"
 elif env["platform"] in ["osx", "macos"]:
-    env["LIBWASMERSUFFIX"] = ".a"
+    env["LIBRUNTIMESUFFIX"] = ".a"
     env.Append(LINKFLAGS=["-framework", "Security"])
 elif env["platform"] == "windows":
     if env.get("use_mingw"):  # MinGW
-        env["LIBWASMERSUFFIX"] = ".a"
+        env["LIBRUNTIMESUFFIX"] = ".a"
         env.Append(LIBS=["userenv"])
     else:  # MSVC
-        env["LIBWASMERSUFFIX"] = ".lib"
+        env["LIBRUNTIMESUFFIX"] = ".lib"
         # Force Windows SDK library suffix (see https://github.com/godotengine/godot/issues/23687)
         env.Append(LINKFLAGS=["bcrypt.lib", "userenv.lib", "ws2_32.lib", "advapi32.lib"])
 
 # Explicit static libraries
 runtime_lib = env.File(
     "{runtime}/lib/{prefix}{runtime}{suffix}".format(
-        runtime=env["wasm_runtime"],
+        runtime=module_env["wasm_runtime"],
         prefix=env["LIBPREFIX"],
-        suffix=env.get("LIBWASMERSUFFIX", env["LIBSUFFIX"]),
+        suffix=env.get("LIBRUNTIMESUFFIX", env["LIBSUFFIX"]),
     )
 )
 
 # Linked libraries (global env) and includes (cloned env)
-env.Append(LIBPATH=[env.Dir("{}/lib".format(env["wasm_runtime"])).abspath])
+env.Append(LIBPATH=[env.Dir("{}/lib".format(module_env["wasm_runtime"])).abspath])
 env.Append(LIBS=[runtime_lib])
-module_env.Append(CPPPATH=[env.Dir("wasmer/include").abspath])
+module_env.Append(CPPPATH=[".", "{}/include".format(module_env["wasm_runtime"])])
 
 # Defines for module agnosticism
 module_env.Append(CPPDEFINES=["GODOT_MODULE"])

--- a/SCsub
+++ b/SCsub
@@ -2,6 +2,7 @@ from utils import download_wasmer, VERSION_DEFAULT
 
 opts = Variables([], ARGUMENTS)
 
+opts.Add(EnumVariable("wasm_runtime", "Wasm runtime used", "wasmer", ["wasmer", "wasmtime"]))
 opts.Add(BoolVariable("download_wasmer", "Download Wasmer library", "no"))
 opts.Add("wasmer_version", "Wasmer library version", VERSION_DEFAULT)
 
@@ -29,11 +30,17 @@ elif env["platform"] == "windows":
         env.Append(LINKFLAGS=["bcrypt.lib", "userenv.lib", "ws2_32.lib", "advapi32.lib"])
 
 # Explicit static libraries
-wasmer_lib = env.File("wasmer/lib/{}wasmer{}".format(env["LIBPREFIX"], env.get("LIBWASMERSUFFIX", env["LIBSUFFIX"])))
+runtime_lib = env.File(
+    "{runtime}/lib/{prefix}{runtime}{suffix}".format(
+        runtime=env["wasm_runtime"],
+        prefix=env["LIBPREFIX"],
+        suffix=env.get("LIBWASMERSUFFIX", env["LIBSUFFIX"]),
+    )
+)
 
 # Linked libraries (global env) and includes (cloned env)
-env.Append(LIBPATH=[env.Dir("wasmer/lib").abspath])
-env.Append(LIBS=[wasmer_lib])
+env.Append(LIBPATH=[env.Dir("{}/lib".format(env["wasm_runtime"])).abspath])
+env.Append(LIBS=[runtime_lib])
 module_env.Append(CPPPATH=[env.Dir("wasmer/include").abspath])
 
 # Defines for module agnosticism

--- a/SCsub
+++ b/SCsub
@@ -44,7 +44,7 @@ runtime_lib = env.File(
 # Linked libraries (global env) and includes (cloned env)
 env.Append(LIBPATH=[env.Dir("{}/lib".format(module_env["wasm_runtime"])).abspath])
 env.Append(LIBS=[runtime_lib])
-module_env.Append(CPPPATH=[".", "{}/include".format(module_env["wasm_runtime"])])
+module_env.Append(CPPPATH=[env.Dir("{}/include".format(module_env["wasm_runtime"])).abspath])
 
 # Defines for module agnosticism
 module_env.Append(CPPDEFINES=["GODOT_MODULE"])

--- a/examples/wasm-test/TestMemoryImport.gd
+++ b/examples/wasm-test/TestMemoryImport.gd
@@ -21,12 +21,10 @@ func test_grow_memory():
 	expect_eq(inspect, expected)
 	memory.grow(1)
 	inspect = memory.inspect()
-	expected = {
-		"min": PAGE_SIZE * 2,
-		"max": PAGES_MAX,
-		"current": PAGE_SIZE * 2,
-	}
-	expect_eq(inspect, expected)
+	# Cannot test minimum as Wasmer & Wasmtime behave differently
+	# Wasmer updates minimum to new size while Wasmtime does not
+	expect_eq(inspect.get("max"), PAGES_MAX)
+	expect_eq(inspect.get("current"), PAGE_SIZE * 2)
 
 func test_module_memory():
 	var wasm = Wasm.new()

--- a/src/godot-wasm.cpp
+++ b/src/godot-wasm.cpp
@@ -462,7 +462,7 @@ namespace godot {
       switch (kind) {
         case WASM_EXTERN_FUNC: {
           const wasm_functype_t* func_type = wasm_externtype_as_functype((wasm_externtype_t*)type);
-          const wasm_valtype_vec_t* func_results = wasm_functype_results(func_type); // BAD
+          const wasm_valtype_vec_t* func_results = wasm_functype_results(func_type);
           export_funcs.emplace(key, godot_wasm::context_func_export(i, func_results->size));
           break;
         } case WASM_EXTERN_GLOBAL:

--- a/src/godot-wasm.cpp
+++ b/src/godot-wasm.cpp
@@ -458,14 +458,14 @@ namespace godot {
     for (uint16_t i = 0; i < exports.size; i++) {
       const wasm_externtype_t* type = wasm_exporttype_type(exports.data[i]);
       const wasm_externkind_t kind = wasm_externtype_kind(type);
-      const wasm_functype_t* func_type = wasm_externtype_as_functype((wasm_externtype_t*)type);
-      const wasm_valtype_vec_t* func_results = wasm_functype_results(func_type);
       const String key = decode_name(wasm_exporttype_name(exports.data[i]));
       switch (kind) {
-        case WASM_EXTERN_FUNC:
+        case WASM_EXTERN_FUNC: {
+          const wasm_functype_t* func_type = wasm_externtype_as_functype((wasm_externtype_t*)type);
+          const wasm_valtype_vec_t* func_results = wasm_functype_results(func_type); // BAD
           export_funcs.emplace(key, godot_wasm::context_func_export(i, func_results->size));
           break;
-        case WASM_EXTERN_GLOBAL:
+        } case WASM_EXTERN_GLOBAL:
           export_globals.emplace(key, godot_wasm::context_extern(i));
           break;
         case WASM_EXTERN_MEMORY:

--- a/src/godot-wasm.h
+++ b/src/godot-wasm.h
@@ -2,7 +2,7 @@
 #define GODOT_WASM_H
 
 #include <map>
-#include "wasmer.h"
+#include "wasm.h"
 #include "defs.h"
 #include "wasm-memory.h"
 

--- a/src/store.h
+++ b/src/store.h
@@ -1,7 +1,7 @@
 #ifndef GODOT_WASM_STORE_H
 #define GODOT_WASM_STORE_H
 
-#include "wasmer.h"
+#include "wasm.h"
 
 #define STORE ::godot_wasm::Store::instance().store
 

--- a/src/wasi-shim.h
+++ b/src/wasi-shim.h
@@ -2,7 +2,7 @@
 #define WASI_SHIM_H
 
 #include <functional>
-#include "wasmer.h"
+#include "wasm.h"
 #include "defs.h"
 
 namespace godot {

--- a/src/wasm-memory.cpp
+++ b/src/wasm-memory.cpp
@@ -1,4 +1,4 @@
-#include "wasmer.h"
+#include "wasm.h"
 #include "wasm-memory.h"
 #include "store.h"
 


### PR DESCRIPTION
Uses generic [Wasm C API](https://github.com/WebAssembly/wasm-c-api) headers. Changes args provided to SConstruct when building as Godot addon (GDExtension/GDNative) or Godot module. New arguments are as follows. Defaults remain unchanged so the typical SConstruct build commands as documented [here](https://github.com/ashtonmeuser/godot-wasm/wiki/Getting-Started) will be unchanged.
- `wasm_runtime`: Either "wasmer" or "wasmtime". Defaults to Wasmer if omitted.
- `runtime_version`: The version of Wasmer or Wasmtime. Defaults are provided if this argument is omitted.
- `download_runtime`: Force a (re)download of the runtime library. This will clear the local _wasmer_ or _wasmtime_ directory and download the library.