### PR TITLE
Migrate to Godot 4.1

### DIFF
--- a/.github/workflows/addon.yml
+++ b/.github/workflows/addon.yml
@@ -7,7 +7,7 @@ on:
 env:
   GODOT_MAJOR: 4
   TARGET: template_release
-  GODOT_REF: 4.0.4-stable
+  GODOT_REF: 4.1.1-stable
   LIBRARY_PATH: addons/godot-wasm/bin
 
 jobs:

--- a/addons/godot-wasm/godot-wasm.gdextension
+++ b/addons/godot-wasm/godot-wasm.gdextension
@@ -1,5 +1,6 @@
 [configuration]
 entry_symbol = "wasm_library_init"
+compatibility_minimum = 4.1
 
 [libraries]
 windows.debug.x86_64 = "bin/windows/godot-wasm.dll"

--- a/examples/wasm-test/project.godot
+++ b/examples/wasm-test/project.godot
@@ -12,7 +12,7 @@ config_version=5
 
 config/name="Wasm Test"
 run/main_scene="res://Main.tscn"
-config/features=PackedStringArray("4.0", "GL Compatibility")
+config/features=PackedStringArray("4.1", "GL Compatibility")
 
 [debug]
 

--- a/examples/wasm-test/utils/TestSuite.gd
+++ b/examples/wasm-test/utils/TestSuite.gd
@@ -35,7 +35,7 @@ func expect_empty():
 	expect_log("")
 
 func expect_error(s: String):
-	expect_log("(USER )?ERROR: " + s)
+	expect_log("((USER )?ERROR: )?" + s)
 	# Account for error stack trace
 	var regex = Utils.make_regex("^\\s+at:\\s")
 	var position = _log_file.get_position()

--- a/register_types.cpp
+++ b/register_types.cpp
@@ -22,8 +22,8 @@ void uninitialize_wasm_module(ModuleInitializationLevel p_level) {
 #ifndef GODOT_MODULE
 
 extern "C" {
-  GDExtensionBool GDE_EXPORT wasm_library_init(const GDExtensionInterface *p_interface, const GDExtensionClassLibraryPtr p_library, GDExtensionInitialization *r_initialization) {
-    godot::GDExtensionBinding::InitObject init_obj(p_interface, p_library, r_initialization);
+  GDExtensionBool GDE_EXPORT wasm_library_init(GDExtensionInterfaceGetProcAddress p_get_proc_address, const GDExtensionClassLibraryPtr p_library, GDExtensionInitialization *r_initialization) {
+    godot::GDExtensionBinding::InitObject init_obj(p_get_proc_address, p_library, r_initialization);
 
     init_obj.register_initializer(initialize_wasm_module);
     init_obj.register_terminator(uninitialize_wasm_module);


### PR DESCRIPTION
Closes #53. Not compatible with Godot 4.0. Future releases of Godot Wasm will drop support for Godot 4.0 in favour of 4.1+ although [v0.3.1](https://github.com/ashtonmeuser/godot-wasm/releases/tag/v0.3.1-godot-4) and prior will target 4.0.