### PR TITLE
Change errors to warnings when type is not compatible

### DIFF
--- a/src/wasm.cpp
+++ b/src/wasm.cpp
@@ -491,12 +491,10 @@ namespace godot {
           memory_context = new godot_wasm::ContextMemory(i, true);
           break;
         case WASM_EXTERN_TABLE:
-          WARN_PRINT(vformat("Import type 'WASM_EXTERN_TABLE' for %s not implemented", key));
+          WARN_PRINT("Tables not implemented for import " + key);
           break;
-        default:
-          WARN_PRINT(vformat("Import type for %s not implemented", key));
-          break;
-		}
+        default: WARN_PRINT("Type not implemented for import " + key);
+      }
     }
 
     // Module exports
@@ -519,11 +517,9 @@ namespace godot {
           if (memory_context == NULL) memory_context = new godot_wasm::ContextMemory(i, false); // Favour import memory
           break;
         case WASM_EXTERN_TABLE:
-          WARN_PRINT(vformat("Export type 'WASM_EXTERN_TABLE' for %s not implemented", key));
+          WARN_PRINT("Tables not implemented for export " + key);
           break;
-        default:
-          WARN_PRINT(vformat("Export type for %s not implemented", key));
-          break;
+        default: WARN_PRINT("Type not implemented for export " + key);
       }
     }
 


### PR DESCRIPTION
The reason for that change is that when a import or export is not available, it prevents other functions that should be supported from working, causing a massive amount of confusion when a export should appear in the list of inspected elements but doesn't.

For example, I had the export `_initialize` being visible with emnn, but inspect was not showing it at all and it was not being called even though it should've be called automatically and it was casing issues.

With things being changed to a warning, `_initialize` appears and works.